### PR TITLE
Fix OpenVSP Import

### DIFF
--- a/trunk/SUAVE/Input_Output/OpenVSP/get_fuel_tank_properties.py
+++ b/trunk/SUAVE/Input_Output/OpenVSP/get_fuel_tank_properties.py
@@ -5,7 +5,7 @@
 # Modified: Oct 2018, T. MacDonald
 
 try:
-    import vsp_g as vsp
+    import vsp as vsp
 except ImportError:
     pass # This allows SUAVE to build without OpenVSP
 import numpy as np

--- a/trunk/SUAVE/Input_Output/OpenVSP/get_fuel_tank_properties.py
+++ b/trunk/SUAVE/Input_Output/OpenVSP/get_fuel_tank_properties.py
@@ -3,6 +3,7 @@
 # 
 # Created:  Sep 2018, T. MacDonald
 # Modified: Oct 2018, T. MacDonald
+#           Jan 2020, T. MacDonald
 
 try:
     import vsp as vsp

--- a/trunk/SUAVE/Input_Output/OpenVSP/get_vsp_areas.py
+++ b/trunk/SUAVE/Input_Output/OpenVSP/get_vsp_areas.py
@@ -4,6 +4,7 @@
 # Created:  --- 2016, T. MacDonald
 # Modified: Aug 2017, T. MacDonald
 #           Mar 2018, T. MacDonald
+#           Jan 2020, T. MacDonald
 
 try:
     import vsp as vsp

--- a/trunk/SUAVE/Input_Output/OpenVSP/get_vsp_areas.py
+++ b/trunk/SUAVE/Input_Output/OpenVSP/get_vsp_areas.py
@@ -6,7 +6,7 @@
 #           Mar 2018, T. MacDonald
 
 try:
-    import vsp_g as vsp
+    import vsp as vsp
 except ImportError:
     pass # This allows SUAVE to build without OpenVSP
 import numpy as np

--- a/trunk/SUAVE/Input_Output/OpenVSP/vsp_read.py
+++ b/trunk/SUAVE/Input_Output/OpenVSP/vsp_read.py
@@ -3,6 +3,7 @@
 
 # Created:  Jun 2018, T. St Francis
 # Modified: Aug 2018, T. St Francis
+#           Jan 2020, T. MacDonald
 
 # ----------------------------------------------------------------------
 #  Imports

--- a/trunk/SUAVE/Input_Output/OpenVSP/vsp_read.py
+++ b/trunk/SUAVE/Input_Output/OpenVSP/vsp_read.py
@@ -13,7 +13,7 @@ from SUAVE.Core import Units, Data
 from SUAVE.Input_Output.OpenVSP import get_vsp_areas
 from SUAVE.Components.Wings.Airfoils.Airfoil import Airfoil 
 from SUAVE.Components.Fuselages.Fuselage import Fuselage
-import vsp_g as vsp
+import vsp as vsp
 import numpy as np
 
 

--- a/trunk/SUAVE/Input_Output/OpenVSP/vsp_read_fuselage.py
+++ b/trunk/SUAVE/Input_Output/OpenVSP/vsp_read_fuselage.py
@@ -12,7 +12,7 @@ import SUAVE
 from SUAVE.Core import Units, Data
 from SUAVE.Input_Output.OpenVSP import get_vsp_areas
 from SUAVE.Components.Fuselages.Fuselage import Fuselage
-import vsp_g as vsp
+import vsp as vsp
 import numpy as np
 
 

--- a/trunk/SUAVE/Input_Output/OpenVSP/vsp_read_fuselage.py
+++ b/trunk/SUAVE/Input_Output/OpenVSP/vsp_read_fuselage.py
@@ -3,6 +3,7 @@
 
 # Created:  Jun 2018, T. St Francis
 # Modified: Aug 2018, T. St Francis
+#           Jan 2020, T. MacDonald
 
 # ----------------------------------------------------------------------
 #  Imports

--- a/trunk/SUAVE/Input_Output/OpenVSP/vsp_read_wing.py
+++ b/trunk/SUAVE/Input_Output/OpenVSP/vsp_read_wing.py
@@ -12,7 +12,7 @@ import SUAVE
 from SUAVE.Core import Units, Data
 from SUAVE.Input_Output.OpenVSP import get_vsp_areas
 from SUAVE.Components.Wings.Airfoils.Airfoil import Airfoil 
-import vsp_g as vsp
+import vsp as vsp
 import numpy as np
 
 ## @ingroup Input_Output-OpenVSP

--- a/trunk/SUAVE/Input_Output/OpenVSP/vsp_read_wing.py
+++ b/trunk/SUAVE/Input_Output/OpenVSP/vsp_read_wing.py
@@ -3,6 +3,7 @@
 
 # Created:  Jun 2018, T. St Francis
 # Modified: Aug 2018, T. St Francis
+#           Jan 2020, T. MacDonald
 
 # ----------------------------------------------------------------------
 #  Imports

--- a/trunk/SUAVE/Input_Output/OpenVSP/vsp_write.py
+++ b/trunk/SUAVE/Input_Output/OpenVSP/vsp_write.py
@@ -16,7 +16,7 @@ import SUAVE
 from SUAVE.Core import Units, Data
 
 try:
-    import vsp_g as vsp
+    import vsp as vsp
 except ImportError:
     # This allows SUAVE to build without OpenVSP
     pass

--- a/trunk/SUAVE/Input_Output/OpenVSP/vsp_write.py
+++ b/trunk/SUAVE/Input_Output/OpenVSP/vsp_write.py
@@ -7,6 +7,7 @@
 #           Oct 2018, T. MacDonald
 #           Nov 2018, T. MacDonald
 #           Jan 2019, T. MacDonald
+#           Jan 2020, T. MacDonald
 
 # ----------------------------------------------------------------------
 #  Imports

--- a/trunk/SUAVE/Input_Output/OpenVSP/write_vsp_mesh.py
+++ b/trunk/SUAVE/Input_Output/OpenVSP/write_vsp_mesh.py
@@ -5,6 +5,7 @@
 # Modified: Jan 2017, T. MacDonald
 #           Feb 2017, T. MacDonald
 #           Jan 2019, T. MacDonald
+#           Jan 2020, T. MacDonald
 
 try:
     import vsp as vsp

--- a/trunk/SUAVE/Input_Output/OpenVSP/write_vsp_mesh.py
+++ b/trunk/SUAVE/Input_Output/OpenVSP/write_vsp_mesh.py
@@ -7,7 +7,7 @@
 #           Jan 2019, T. MacDonald
 
 try:
-    import vsp_g as vsp
+    import vsp as vsp
 except ImportError:
     pass # This allows SUAVE to build without OpenVSP
 import numpy as np


### PR DESCRIPTION
This changes the OpenVSP import to be consistent with the new OpenVSP API. The name vsp_g no longer works in the new version.