### PR TITLE
Lift Wave Drag Revision

### DIFF
--- a/trunk/SUAVE/Analyses/Aerodynamics/Supersonic_Zero.py
+++ b/trunk/SUAVE/Analyses/Aerodynamics/Supersonic_Zero.py
@@ -86,7 +86,7 @@ class Supersonic_Zero(Markup):
         # be used
         # 'OpenVSP' is a desired future possibility. This would allow the cross sectional area to vary with Mach number, but is 
         # much more computationally intensive.        
-        settings.volume_wave_drag_scaling    = 3.7 # 1.8-2.2 are given as typical for an SST, but 3.7 was found to be more accurate 
+        settings.volume_wave_drag_scaling    = 3.2 # 1.8-2.2 are given as typical for an SST, but 3.2 was found to be more accurate 
         # This may be due to added propulsion effects
         settings.fuselage_parasite_drag_begin_blend_mach = 0.91
         settings.fuselage_parasite_drag_end_blend_mach   = 0.99

--- a/trunk/SUAVE/Methods/Aerodynamics/Supersonic_Zero/Drag/wave_drag_lift.py
+++ b/trunk/SUAVE/Methods/Aerodynamics/Supersonic_Zero/Drag/wave_drag_lift.py
@@ -2,14 +2,13 @@
 # wave_drag_lift.py
 # 
 # Created:  Feb 2019, T. MacDonald
-# Modified: 
+# Modified: Feb 2021, T. MacDonald
 
 # ----------------------------------------------------------------------
 #  Imports
 # ----------------------------------------------------------------------
 
 import numpy as np
-from SUAVE.Core import Data
 from SUAVE.Components.Wings import Main_Wing
 
 # ----------------------------------------------------------------------
@@ -21,16 +20,18 @@ def wave_drag_lift(conditions,configuration,wing):
     """Computes wave drag due to lift
 
     Assumptions:
-    Simplified equations
+    Main wing is the primary lift contributor
 
     Source:
-    http://aerodesign.stanford.edu/aircraftdesign/drag/ssdragcalc.html
+    Yoshida, Kenji. "Supersonic drag reduction technology in the scaled supersonic 
+    experimental airplane project by JAXA."
 
     Inputs:
     conditions.freestream.mach_number        [Unitless]
     conditions.aerodynamics.lift_coefficient [Unitless]
+    wing.spans.projected                     [m]
     wing.total_length                        [m]
-    wing.areas.reference                     [m^2]
+    wing.aspect_ratio                        [-]
 
     Outputs:
     wave_drag_lift                           [Unitless]
@@ -41,36 +42,55 @@ def wave_drag_lift(conditions,configuration,wing):
 
     # Unpack
     freestream   = conditions.freestream
-    total_length = wing.total_length
-    Sref         = wing.areas.reference
     
     # Conditions
     Mc  = freestream.mach_number * 1.0
-
-    # Length-wise aspect ratio
-    ARL = total_length**2/Sref
     
     # Lift coefficient
     if isinstance(wing,Main_Wing):
         CL = conditions.aerodynamics.lift_coefficient
     else:
         CL = np.zeros_like(conditions.aerodynamics.lift_coefficient)
+
+    # JAXA method
+    s    = wing.spans.projected / 2
+    l    = wing.total_length
+    AR   = wing.aspect_ratio
+    p    = 2/AR*s/l
+    beta = np.sqrt(Mc[Mc >= 1.01]**2-1)
     
-    mach_ind = Mc >= 1.01
+    Kw = (1+1/p)*fw(beta*s/l)/(2*beta**2*(s/l)**2)
     
-    # Computations
-    x = np.pi*ARL/4
-    beta = np.array([[0.0]] * len(Mc))
-    beta[Mc >= 1.01] = np.sqrt(Mc[Mc >= 1.01]**2-1)
-    wave_drag_lift = np.array([[0.0]] * len(Mc))
-    wave_drag_lift[Mc >= 1.01] = CL[Mc >= 1.01]**2*x/4*(np.sqrt(1+(beta[Mc >= 1.01]/x)**2)-1)
-    wave_drag_lift[0:len(Mc[Mc >= 1.01]),0] = wave_drag_lift[Mc >= 1.01]
-    
-    # Dump data to conditions
-    wave_lift_result = Data(
-        reference_area             = Sref   , 
-        wave_drag_lift_coefficient = wave_drag_lift ,
-        length_AR                  = ARL,
-    )
+    # Ignore area comparison since this is full vehicle CL
+    CDwl = CL[Mc >= 1.01]**2 * (beta**2/np.pi*p*(s/l)*Kw)
+    wave_drag_lift = np.zeros_like(Mc)
+    wave_drag_lift[Mc >= 1.01] = CDwl
 
     return wave_drag_lift
+
+def fw(x):
+    """Helper function for lift wave drag computations.
+
+    Assumptions:
+    N/A
+
+    Source:
+    Yoshida, Kenji. "Supersonic drag reduction technology in the scaled supersonic 
+    experimental airplane project by JAXA."
+
+    Inputs:
+    x    [Unitless]
+
+    Outputs:
+    ret  [Unitless]
+
+    Properties Used:
+    N/A
+    """  
+    
+    ret = np.zeros_like(x)
+    
+    ret[x > 0.178] = 0.4935 - 0.2382*x[x > 0.178] + 1.6306*x[x > 0.178]**2 - \
+        0.86*x[x > 0.178]**3 + 0.2232*x[x > 0.178]**4 - 0.0365*x[x > 0.178]**5 - 0.5
+    
+    return ret


### PR DESCRIPTION
This change provides a method for lift wave drag that was found to predict the Concorde results better than the previous one. I removed the previous one instead of giving an option because it seemed too far off to keep around. I also revised the volume wave drag scaling factor to keep our own Concorde results properly calibrated.