### PR TITLE
correct origin offset y/z switching for vertical control surfaces

### DIFF
--- a/trunk/SUAVE/Methods/Aerodynamics/Common/Fidelity_Zero/Lift/make_VLM_wings.py
+++ b/trunk/SUAVE/Methods/Aerodynamics/Common/Fidelity_Zero/Lift/make_VLM_wings.py
@@ -443,10 +443,8 @@ def make_cs_wing_from_cs(cs, seg_a, seg_b, wing, cs_ID):
     wing_halfspan                 = wing.spans.projected * 0.5 if wing.symmetric else wing.spans.projected
     LE_TE_cs_offset               = 0. if cs_wing.is_slat else (1 - cs.chord_fraction)*wing_chord_local_at_cs_root
     cs_wing.origin[0,0]          += np.interp(cs.span_fraction_start, [span_a, span_b], [seg_a.x_offset, seg_b.x_offset]) + LE_TE_cs_offset
-    cs_wing.origin[0,1]          += cs.span_fraction_start * wing_halfspan
-    cs_wing.origin[0,2]          += np.interp(cs.span_fraction_start, [span_a, span_b], [seg_a.dih_offset, seg_b.dih_offset])
-    if wing.vertical:
-        cs_wing[0,1], cs_wing[0,2] = cs_wing[0,2], cs_wing[0,1]
+    cs_wing.origin[0,1]          += cs.span_fraction_start * wing_halfspan if not wing.vertical else np.interp(cs.span_fraction_start, [span_a, span_b], [seg_a.dih_offset, seg_b.dih_offset])
+    cs_wing.origin[0,2]          += np.interp(cs.span_fraction_start, [span_a, span_b], [seg_a.dih_offset, seg_b.dih_offset]) if not wing.vertical else cs.span_fraction_start * wing_halfspan
     
     # holds all required y-coords. Will be added to during discretization to ensure y-coords match up between wing and control surface.
     rel_offset                    = cs_wing.origin[0,1] - wing.origin[0][1] if not cs_wing.vertical else cs_wing.origin[0,2] - wing.origin[0][2]


### PR DESCRIPTION
This fixes a bug where vertical control surfaces threw an error, and even if that error was suppressed, the surfaces had the wrong origin. 

Credit to Michael for finding this bug.
